### PR TITLE
archlinux AUR packaging

### DIFF
--- a/.arch/PKGBUILD
+++ b/.arch/PKGBUILD
@@ -1,14 +1,14 @@
 # @Author: archer
 # @Date:   2019-07-23T10:07:36+01:00
 # @Last modified by:   archer
-# @Last modified time: 2019-07-23T10:44:21+01:00
+# @Last modified time: 2019-07-23T10:51:20+01:00
 
 
 
 # Maintainer: George Raven <GeorgeRavenCommunity AT pm dot me>
 pkgname=python-simple-data-transport-git
 _pkgsrcname="SimpleDataTransport"
-pkgver=1.5
+pkgver=1.5.r0.460c80c
 pkgrel=1
 pkgdesc="Simple python 2/3 library for transporting data to a remote machine, applying transformations and returning a response."
 arch=('any')

--- a/.arch/PKGBUILD
+++ b/.arch/PKGBUILD
@@ -1,0 +1,54 @@
+# @Author: archer
+# @Date:   2019-07-23T10:07:36+01:00
+# @Last modified by:   archer
+# @Last modified time: 2019-07-23T10:44:21+01:00
+
+
+
+# Maintainer: George Raven <GeorgeRavenCommunity AT pm dot me>
+pkgname=python-simple-data-transport-git
+_pkgsrcname="SimpleDataTransport"
+pkgver=1.5
+pkgrel=1
+pkgdesc="Simple python 2/3 library for transporting data to a remote machine, applying transformations and returning a response."
+arch=('any')
+url="https://github.com/RaymondKirk/${_pkgsrcname}"
+_branch="master"
+license=('MIT') # MIT is a special case store a copy in /usr/share/pkgname
+groups=()
+depends=('python-flask' 'python-numpy' 'python-requests' 'python-jsonpickle')
+makedepends=('git')
+optdepends=()
+provides=()
+conflicts=()
+replaces=()
+backup=()
+options=()
+install=
+source=("${_pkgsrcname}::git+${url}#branch=${_branch}")
+noextract=()
+md5sums=('SKIP')
+
+pkgver() {
+	cd "$srcdir/${_pkgsrcname}"
+	printf "%s" "$(git describe --long | sed 's/\([^-]*-\)g/r\1/;s/-/./g')"
+}
+
+prepare() {
+	cd "$srcdir/${_pkgsrcname}"
+	git checkout ${_branch} # get off of makepkg branch
+}
+
+build() {
+	cd "$srcdir/${_pkgsrcname}"
+}
+
+check() {
+	cd "$srcdir/${_pkgsrcname}"
+}
+
+package() {
+	cd "$srcdir/${_pkgsrcname}"
+	python3 setup.py install --prefix=/usr --root="$pkgdir/" --optimize=1
+	install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore everything that isnt already tracked
+# please use "git add -f foo.txt" to force into tracking.
+/*

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,14 @@
+# @Author: archer
+# @Date:   2019-07-23T10:25:25+01:00
+# @Last modified by:   archer
+# @Last modified time: 2019-07-23T10:25:41+01:00
+
+
 import setuptools
 
 setuptools.setup(
     name='SimpleDataTransport',
-    version='1.3',
+    version='1.5',
     author="Raymond Tunstill",
     author_email="ray.tunstill@live.co.uk",
     description="Simple python 2/3 library for transporting images/data to a remote machine, applying transformations "


### PR DESCRIPTION
I wanted to install your library on Archlinux, as such I needed it to be pacman packagable.
As such I created a PKGBUILD file for archers to install your package, and a few other adjustments to bring your repository to a consistent version across pypi (1.4) and the setup.py (1.3) to version 1.5. If you could _please release an annotated tag_ for version **1.5** then the PKGBUILD will work.

I have taken the liberty of bumping the version in your setup.py and putting in a whitelist .gitignore so that packaging is cleaner since packages can now co-exist in the source tree.